### PR TITLE
add notebook image build to chartpress

### DIFF
--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -7,4 +7,4 @@ charts:
     images:
       notebook:
         contextPath: docker-images/notebook
-        valuesPath: singleuser.image
+        valuesPath: jupyterhub.singleuser.image

--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -3,3 +3,8 @@ charts:
     repo:
       git: pangeo-data/helm-chart
       published: https://pangeo-data.github.io/helm-chart
+    images:
+      notebook:
+        contextPath: docker-images/notebook
+        # path in values.yaml to be updated with image name and tag
+        valuesPath: image

--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -1,10 +1,10 @@
 charts:
   - name: pangeo
+    imagePrefix: pangeo/
     repo:
       git: pangeo-data/helm-chart
       published: https://pangeo-data.github.io/helm-chart
     images:
       notebook:
         contextPath: docker-images/notebook
-        # path in values.yaml to be updated with image name and tag
-        valuesPath: image
+        valuesPath: singleuser.image


### PR DESCRIPTION
Based on my understanding of the chartpress readme:
https://github.com/jupyterhub/chartpress
...this should auto-build the notebook docker image.

cc @mrocklin, @tjcrone, @jacobtomlinson, @yuvipanda