### PR TITLE
remove resource specs

### DIFF
--- a/pangeo/values.yaml
+++ b/pangeo/values.yaml
@@ -23,3 +23,14 @@ jupyterhub:
       tag: e02bc75c40df01454dd01bd6ae55e0213ada7563
     defaultUrl: "/lab"
     serviceAccountName: daskkubernetes
+
+# Resource specifications
+# -----------------------
+# (specific deployments of this chart should add this section to local helm config)
+#
+#    cpu:
+#      limit: 2
+#      guarantee: 1
+#    memory:
+#      limit: 4G
+#      guarantee: 2G

--- a/pangeo/values.yaml
+++ b/pangeo/values.yaml
@@ -21,11 +21,5 @@ jupyterhub:
     image:
       name: pangeo/notebook
       tag: e02bc75c40df01454dd01bd6ae55e0213ada7563
-    cpu:
-      limit: 2
-      guarantee: 1
-    memory:
-      limit: 4G
-      guarantee: 2G
     defaultUrl: "/lab"
     serviceAccountName: daskkubernetes


### PR DESCRIPTION
After some discussion with @tjcrone, I am starting to think that the resource specs should be specified in the deployment-specific config (e.g. [jupyter-config.yaml](https://github.com/pangeo-data/pangeo/blob/master/gce/jupyter-config.yaml) for pangeo.pydata.org), rather than here in the generic helm chart. We override them there already, so their presence here is confusing.