### PR TITLE
WIP: add docker push to deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 
+set -eu
 openssl aes-256-cbc -K $encrypted_058f1ad78f7f_key -iv $encrypted_058f1ad78f7f_iv -in deploy-key.rsa.enc -out deploy-key.rsa -d
+set -x
 chmod 0400 deploy-key.rsa
-
+docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}"
 helm init --client-only
 helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
 helm repo update
-
 helm dependency update pangeo
-GIT_SSH_COMMAND="ssh -i ${PWD}/deploy-key.rsa" chartpress --commit-range ${TRAVIS_COMMIT_RANGE} --publish-chart --push
+export GIT_SSH_COMMAND="ssh -i ${PWD}/deploy-key.rsa"
+chartpress --commit-range ${TRAVIS_COMMIT_RANGE} --publish-chart --push
+git diff

--- a/deploy.sh
+++ b/deploy.sh
@@ -8,4 +8,4 @@ helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
 helm repo update
 
 helm dependency update pangeo
-GIT_SSH_COMMAND="ssh -i ${PWD}/deploy-key.rsa" chartpress --commit-range ${TRAVIS_COMMIT_RANGE} --publish-chart
+GIT_SSH_COMMAND="ssh -i ${PWD}/deploy-key.rsa" chartpress --commit-range ${TRAVIS_COMMIT_RANGE} --publish-chart --push


### PR DESCRIPTION
The latest helm chart built by chartpress (pangeo-v0.1.1-0234fc7) is unusable because the docker image was never pushed to docker hub. That's because our `deploy.sh` script does not include the `--push` flag.

This PR will not work in its current form because we have to add docker authentication. For an example, look at the zero-to-jupyterhub-k8 deploy script:
https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/master/ci/deploy.sh

In order to make this work, we need to
- [ ] make a pangeo docker account for CI (will require an email address)
- [ ] encrypt the credentials and add them to this repo somehow

We already have some encrypted secrets in this repo in order to publish the chart to github pages. I am out of my depth in terms of all the travis magic required to make this work. Help needed!

cc @jacobtomlinson, @martindurant

(The reason I am working on this on Saturday night is that I need to fix #39 asap so I can get back to the actual science work I am trying to do on pangeo.pydata.org.)
