### PR TITLE
Clone external notebooks repo

### DIFF
--- a/docker-images/notebook/Dockerfile
+++ b/docker-images/notebook/Dockerfile
@@ -79,7 +79,7 @@ COPY prepare.sh /usr/bin/prepare.sh
 RUN chmod +x /usr/bin/prepare.sh
 RUN mkdir /home/$NB_USER/examples && chown -R $NB_USER /home/$NB_USER/examples
 RUN mkdir /pre-home && mkdir /pre-home/examples && chown -R $NB_USER /pre-home
-COPY examples/ /pre-home/examples/
+# COPY examples/ /pre-home/examples/
 
 ENV DASK_CONFIG=/home/$NB_USER/config.yaml
 COPY config.yaml /pre-home

--- a/docker-images/notebook/Dockerfile
+++ b/docker-images/notebook/Dockerfile
@@ -80,7 +80,6 @@ COPY prepare.sh /usr/bin/prepare.sh
 RUN chmod +x /usr/bin/prepare.sh
 RUN mkdir /home/$NB_USER/examples && chown -R $NB_USER /home/$NB_USER/examples
 RUN mkdir /pre-home && mkdir /pre-home/examples && chown -R $NB_USER /pre-home
-# COPY examples/ /pre-home/examples/
 
 ENV DASK_CONFIG=/home/$NB_USER/config.yaml
 COPY config.yaml /pre-home

--- a/docker-images/notebook/prepare.sh
+++ b/docker-images/notebook/prepare.sh
@@ -7,8 +7,11 @@ cp --update -r -v /pre-home/. /home/jovyan
 rm -rf /pre-home/git
 git clone https://github.com/pangeo-data/pangeo-example-notebooks /pre-home/git
 cd /pre-home/git
-DATESTAMP=`git log -1 --format=%cd --date=short`
-for file in  *.ipynb; do cp --update "$file" /home/jovyan/examples/"${file/.ipynb/_$DATESTAMP.ipynb}"; done
+for file in  *.ipynb;
+do
+    DATESTAMP=`git log -1 --format="%cd" --date=short -- $file`
+    cp --update "$file" /home/jovyan/examples/"${file/.ipynb/_$DATESTAMP.ipynb}";
+done
 touch /home/jovyan/examples/PROVIDED_EXAMPLE_NOTEBOOKS.md
 cd
 

--- a/docker-images/notebook/prepare.sh
+++ b/docker-images/notebook/prepare.sh
@@ -8,15 +8,19 @@ cp --update -r -v /pre-home/. /home/jovyan
 if [ -z "$EXAMPLES_GIT_URL" ]; then
     export EXAMPLES_GIT_URL=https://github.com/pangeo-data/pangeo-example-notebooks
 fi
-git clone $EXAMPLES_GIT_URL examples
+if [ ! -d "examples" ]; then
+  git clone $EXAMPLES_GIT_URL examples
+fi
 cd examples
 git remote set-url origin $EXAMPLES_GIT_URL
 git fetch origin
 git reset --hard origin/master
 git merge --strategy-option=theirs origin/master
-echo "Files in this directory should be treated as read-only"  > DONT_SAVE_ANYTHING_HERE.md
+if [ ! -f DONT_SAVE_ANYTHING_HERE.md ]; then
+  echo "Files in this directory should be treated as read-only"  > DONT_SAVE_ANYTHING_HERE.md
+fi
 cd ..
-mkdir work
+mkdir -p work
 
 if [ -e "/opt/app/environment.yml" ]; then
     echo "environment.yml found. Installing packages"

--- a/docker-images/notebook/prepare.sh
+++ b/docker-images/notebook/prepare.sh
@@ -5,7 +5,7 @@ set -x
 echo "Copy files from pre-load directory into home"
 cp --update -r -v /pre-home/. /home/jovyan
 rm -rf /pre-home/git
-git clone https://github.com/martindurant/pangeo-example-notebooks /pre-home/git
+git clone https://github.com/pangeo-data/pangeo-example-notebooks /pre-home/git
 cd /pre-home/git
 DATESTAMP=`git log -1 --format=%cd --date=short`
 for file in  *.ipynb; do cp --update "$file" /home/jovyan/examples/"${file/.ipynb/_$DATESTAMP.ipynb}"; done

--- a/docker-images/notebook/prepare.sh
+++ b/docker-images/notebook/prepare.sh
@@ -4,6 +4,13 @@ set -x
 
 echo "Copy files from pre-load directory into home"
 cp --update -r -v /pre-home/. /home/jovyan
+rm -rf /pre-home/git
+git clone https://github.com/martindurant/pangeo-example-notebooks /pre-home/git
+cd /pre-home/git
+DATESTAMP=`git log -1 --format=%cd --date=short`
+for file in  *.ipynb; do cp --update "$file" /home/jovyan/examples/"${file/.ipynb/_$DATESTAMP.ipynb}"; done
+touch /home/jovyan/examples/PROVIDED_EXAMPLE_NOTEBOOKS.md
+cd
 
 if [ -e "/opt/app/environment.yml" ]; then
     echo "environment.yml found. Installing packages"

--- a/docker-images/notebook/prepare.sh
+++ b/docker-images/notebook/prepare.sh
@@ -4,9 +4,18 @@ set -x
 
 echo "Copy files from pre-load directory into home"
 cp --update -r -v /pre-home/. /home/jovyan
-rm -rf examples
-git clone https://github.com/pangeo-data/pangeo_examples examples
-echo "Files in this directory should be treated as read-only"  > examples/DONT_SAVE_ANYTHING_HERE.md
+
+if [ -z "$EXAMPLES_GIT_URL" ]; then
+    export EXAMPLES_GIT_URL=https://github.com/pangeo-data/pangeo-example-notebooks
+fi
+git clone $EXAMPLES_GIT_URL examples
+cd examples
+git remote set-url origin $EXAMPLES_GIT_URL
+git fetch origin
+git reset --hard origin/master
+git merge --strategy-option=theirs origin/master
+echo "Files in this directory should be treated as read-only"  > DONT_SAVE_ANYTHING_HERE.md
+cd ..
 mkdir work
 
 if [ -e "/opt/app/environment.yml" ]; then

--- a/docker-images/notebook/prepare.sh
+++ b/docker-images/notebook/prepare.sh
@@ -4,16 +4,10 @@ set -x
 
 echo "Copy files from pre-load directory into home"
 cp --update -r -v /pre-home/. /home/jovyan
-rm -rf /pre-home/git
-git clone https://github.com/pangeo-data/pangeo-example-notebooks /pre-home/git
-cd /pre-home/git
-for file in  *.ipynb;
-do
-    DATESTAMP=`git log -1 --format="%cd" --date=short -- $file`
-    cp --update "$file" /home/jovyan/examples/"${file/.ipynb/_$DATESTAMP.ipynb}";
-done
-touch /home/jovyan/examples/PROVIDED_EXAMPLE_NOTEBOOKS.md
-cd
+rm -rf examples
+git clone https://github.com/pangeo-data/pangeo_examples examples
+echo "Files in this directory should be treated as read-only"  > examples/DONT_SAVE_ANYTHING_HERE.md
+mkdir work
 
 if [ -e "/opt/app/environment.yml" ]; then
     echo "environment.yml found. Installing packages"


### PR DESCRIPTION
Instead of baking notebooks into the docker image, download from
a notebook-only repo upon container instantiation.

Notebook names are tagged with commit date, so that edits by a user
do not get overwritten, then just get more notebooks.