### PR TITLE
pin netCDF4 version

### DIFF
--- a/docker-images/notebook/Dockerfile
+++ b/docker-images/notebook/Dockerfile
@@ -34,7 +34,7 @@ RUN conda install --yes \
     matplotlib \
     msgpack-python \
     nb_conda_kernels \
-    netcdf4 \
+    netcdf4>1.4 \
     nomkl \
     numba \
     numcodecs \


### PR DESCRIPTION
This fixes pangeo-data/pangeo#257. By specifying the netCDF4 version > 1.4, we should ensure that cftime gets installed.

This was previously working, and I have no idea where / when it broke.

Also a chance to see whether #40 works.