### PR TITLE
Don't create examples dir, git should do it

### DIFF
--- a/docker-images/notebook/Dockerfile
+++ b/docker-images/notebook/Dockerfile
@@ -81,8 +81,7 @@ RUN jupyter serverextension enable --py nbserverproxy jupyterlab --sys-prefix
 USER root
 COPY prepare.sh /usr/bin/prepare.sh
 RUN chmod +x /usr/bin/prepare.sh
-RUN mkdir /home/$NB_USER/examples && chown -R $NB_USER /home/$NB_USER/examples
-RUN mkdir /pre-home && mkdir /pre-home/examples && chown -R $NB_USER /pre-home
+RUN mkdir /pre-home && chown -R $NB_USER /pre-home
 
 ENV DASK_CONFIG=/home/$NB_USER/config.yaml
 COPY config.yaml /pre-home

--- a/docker-images/notebook/prepare.sh
+++ b/docker-images/notebook/prepare.sh
@@ -8,7 +8,7 @@ cp --update -r -v /pre-home/. /home/jovyan
 if [ -z "$EXAMPLES_GIT_URL" ]; then
     export EXAMPLES_GIT_URL=https://github.com/pangeo-data/pangeo-example-notebooks
 fi
-rmdir examples  # deletes directory if empty, in favour of fresh clone
+rmdir examples > /dev/null # deletes directory if empty, in favour of fresh clone
 if [ ! -d "examples" ]; then
   git clone $EXAMPLES_GIT_URL examples
 fi

--- a/docker-images/notebook/prepare.sh
+++ b/docker-images/notebook/prepare.sh
@@ -8,6 +8,7 @@ cp --update -r -v /pre-home/. /home/jovyan
 if [ -z "$EXAMPLES_GIT_URL" ]; then
     export EXAMPLES_GIT_URL=https://github.com/pangeo-data/pangeo-example-notebooks
 fi
+rmdir examples  # deletes directory if empty, in favour of fresh clone
 if [ ! -d "examples" ]; then
   git clone $EXAMPLES_GIT_URL examples
 fi

--- a/docker-images/notebook/prepare.sh
+++ b/docker-images/notebook/prepare.sh
@@ -8,7 +8,7 @@ cp --update -r -v /pre-home/. /home/jovyan
 if [ -z "$EXAMPLES_GIT_URL" ]; then
     export EXAMPLES_GIT_URL=https://github.com/pangeo-data/pangeo-example-notebooks
 fi
-rmdir examples > /dev/null # deletes directory if empty, in favour of fresh clone
+rmdir examples &> /dev/null # deletes directory if empty, in favour of fresh clone
 if [ ! -d "examples" ]; then
   git clone $EXAMPLES_GIT_URL examples
 fi


### PR DESCRIPTION
Fixes #54 

The original intent in #44 was not to over-write old examples directories predating the move to a separate git repo, but do update the directory if newer, only for those files which are in the repo.
The pre-creation of the examples directory ( https://github.com/pangeo-data/helm-chart/blob/master/docker-images/notebook/Dockerfile#L84 and https://github.com/pangeo-data/helm-chart/blob/master/docker-images/notebook/Dockerfile#L85 ) broke this; but why was it working before?