### PR TITLE
use more recent jupyterhub chart

### DIFF
--- a/pangeo/requirements.yaml
+++ b/pangeo/requirements.yaml
@@ -1,7 +1,7 @@
 # requirements.yaml
 dependencies:
 - name: jupyterhub
-  version: "v0.7-82bed4a"
+  version: "v0.7-1656a02"
   repository: 'https://jupyterhub.github.io/helm-chart/'
   import-values:
     - child: rbac


### PR DESCRIPTION
Much more recent helm charts are available for jupyterhub

Just talked to @yuvipanda...it seems like this should fix https://github.com/pangeo-data/pangeo/issues/358

cc @rsignell-usgs, @jacobtomlinson 

