### PR TITLE
Start with jupyter labhub

### DIFF
--- a/pangeo/values.yaml
+++ b/pangeo/values.yaml
@@ -28,6 +28,7 @@ jupyterhub:
       limit: 4G
       guarantee: 2G
     defaultUrl: "/lab"
+    cmd: jupyter-labhub
     serviceAccountName: daskkubernetes
 
   prePuller:


### PR DESCRIPTION
The [hub extension](https://github.com/jupyterhub/jupyterlab-hub) for Jupyter Lab checks whether you started the server with `jupyter-labhub` before displaying. We are still using the default `jupyterhub-singleuser` command from z2jh so the tab doesn't display.

As far as I can tell changing the start command doesn't affect anything. But I can now see the Hub tab!

![image](https://user-images.githubusercontent.com/1610850/44793388-08770380-ab9e-11e8-8a34-ddb7c43f7dfa.png)



