### PR TITLE
use jupyterhub 0.7.0 chart

### DIFF
--- a/pangeo/requirements.yaml
+++ b/pangeo/requirements.yaml
@@ -1,7 +1,7 @@
 # requirements.yaml
 dependencies:
 - name: jupyterhub
-  version: "v0.7-1656a02"
+  version: "v0.7.0"
   repository: 'https://jupyterhub.github.io/helm-chart/'
   import-values:
     - child: rbac


### PR DESCRIPTION
There is a new release of jupyterhub helm chart out. We should use it.