### PR TITLE
Update preparation script

### DIFF
--- a/docker-images/notebook/Dockerfile
+++ b/docker-images/notebook/Dockerfile
@@ -85,11 +85,11 @@ RUN jupyter serverextension enable --py nbserverproxy jupyterlab --sys-prefix
 USER root
 COPY prepare.sh /usr/bin/prepare.sh
 RUN chmod +x /usr/bin/prepare.sh
-RUN mkdir /pre-home && chown -R $NB_USER /pre-home
+RUN mkdir /etc/skel && chown -R $NB_USER /etc/skel
 
 ENV DASK_CONFIG=/home/$NB_USER/config.yaml
-COPY config.yaml /pre-home
-COPY worker-template.yaml /pre-home
+COPY config.yaml /etc/skel
+COPY worker-template.yaml /etc/skel
 
 RUN mkdir /gcs && chown -R $NB_USER /gcs
 RUN mkdir /opt/app

--- a/docker-images/notebook/Dockerfile
+++ b/docker-images/notebook/Dockerfile
@@ -85,7 +85,7 @@ RUN jupyter serverextension enable --py nbserverproxy jupyterlab --sys-prefix
 USER root
 COPY prepare.sh /usr/bin/prepare.sh
 RUN chmod +x /usr/bin/prepare.sh
-RUN mkdir /etc/skel && chown -R $NB_USER /etc/skel
+RUN chown -R $NB_USER /etc/skel
 
 ENV DASK_CONFIG=/home/$NB_USER/config.yaml
 COPY config.yaml /etc/skel

--- a/docker-images/notebook/prepare.sh
+++ b/docker-images/notebook/prepare.sh
@@ -91,7 +91,7 @@ echo "Done"
 # Mount optional FUSE filesystems #
 ###################################
 
-echo "Mouting FUSE filesystems..."
+echo "Mounting FUSE filesystems..."
 if [ "$GCSFUSE_BUCKET" ]; then
     echo "Mounting $GCSFUSE_BUCKET to /gcs"
     /opt/conda/bin/gcsfuse $GCSFUSE_BUCKET /gcs --background

--- a/docker-images/notebook/prepare.sh
+++ b/docker-images/notebook/prepare.sh
@@ -1,10 +1,47 @@
 #!/bin/bash
 
+#                    .,,,,,.
+#               .,(#         #(,
+#             .*%               #*.
+#            ,#    %%%%%%%%%%%%   #,
+#           ,#     %%%%%%%%%%%%    #,
+#          .(                       (.
+#          ,%    %%%%%%%%%          #,
+#          ,#    %%%%%%%%%          #,
+#          .(                      .(.
+#           ,#     %%%%%%%%%%%%    #,
+#            ,#    %%%%%%%%%%%%   #,
+#             .*#               #*.
+#               .,(#        .#/,
+#                   .,,,,,.
+#       _____
+#      |  __ \
+#      | |__) |_ _ _ __   __ _  ___  ___
+#      |  ___/ _` | '_ \ / _` |/ _ \/ _ \
+#      | |  | (_| | | | | (_| |  __/ (_) |
+#      |_|   \__,_|_| |_|\__, |\___|\___/
+#                         __/ |
+#                        |___/
+#
+# This script sets up the basic user Jupyter home directory for use on Pangeo.
+
 set -x
 
-echo "Copy files from pre-load directory into home"
-cp --update -r -v /pre-home/. /home/jovyan
 
+################################
+# Copy skeleton home directory #
+################################
+
+echo "Copying files from skeleton home directory into home..."
+cp --update -r -v /etc/skel/. /home/jovyan
+echo "Done"
+
+
+#########################
+# Add example notebooks #
+#########################
+
+echo "Getting example notebooks..."
 if [ -z "$EXAMPLES_GIT_URL" ]; then
     export EXAMPLES_GIT_URL=https://github.com/pangeo-data/pangeo-example-notebooks
 fi
@@ -13,6 +50,7 @@ if [ ! -d "examples" ]; then
   git clone $EXAMPLES_GIT_URL examples
 fi
 cd examples
+chmod -R 700 *.ipynb
 git remote set-url origin $EXAMPLES_GIT_URL
 git fetch origin
 git reset --hard origin/master
@@ -20,11 +58,18 @@ git merge --strategy-option=theirs origin/master
 if [ ! -f DONT_SAVE_ANYTHING_HERE.md ]; then
   echo "Files in this directory should be treated as read-only"  > DONT_SAVE_ANYTHING_HERE.md
 fi
+chmod -R 400 *.ipynb
 cd ..
-mkdir -p work
+echo "Done"
 
+
+######################################
+# Install additional Python packages #
+######################################
+
+echo "Installing extra Python packages..."
 if [ -e "/opt/app/environment.yml" ]; then
-    echo "environment.yml found. Installing packages"
+    echo "Conda environment.yml found. Installing packages"
     /opt/conda/bin/conda env update -f /opt/app/environment.yml
 else
     echo "no environment.yml"
@@ -39,10 +84,22 @@ if [ "$EXTRA_PIP_PACKAGES" ]; then
     echo "EXTRA_PIP_PACKAGES environment variable found.  Installing".
     /opt/conda/bin/pip install $EXTRA_PIP_PACKAGES
 fi
+echo "Done"
 
+
+###################################
+# Mount optional FUSE filesystems #
+###################################
+
+echo "Mouting FUSE filesystems..."
 if [ "$GCSFUSE_BUCKET" ]; then
     echo "Mounting $GCSFUSE_BUCKET to /gcs"
     /opt/conda/bin/gcsfuse $GCSFUSE_BUCKET /gcs --background
 fi
-# Run extra commands
+echo "Done"
+
+
+######################
+# Run extra commands #
+######################
 $@


### PR DESCRIPTION
I was looking through the `prepare.sh` script to add a few Informatics Lab specific things and thought I'd give it a little tidy upstream too.

This PR includes the following changes:
 - More comments
 - More echo statements to explain what is happening
 - Some ASCII art at the top (the sysadmin in me made me do it!)
 - Remove the creation of the `work` directory. Thought it was oddly specific.
 - Moved `/pre-home` to `/etc/skel` which is the standard location to store a skeleton home directory
 - Mark all notebooks in the examples directory as read only. This results in a permissions error if you try to edit and save an example. 