### PR TITLE
Bump z2jh chart version

### DIFF
--- a/pangeo/requirements.yaml
+++ b/pangeo/requirements.yaml
@@ -1,7 +1,7 @@
 # requirements.yaml
 dependencies:
 - name: jupyterhub
-  version: "v0.8.0"
+  version: "0.9-e120fda"
   repository: 'https://jupyterhub.github.io/helm-chart/'
   import-values:
     - child: rbac


### PR DESCRIPTION
Need https://github.com/jupyterhub/zero-to-jupyterhub-k8s/commit/4e9b4a22f516a7f7545c1cfebe440f0b2dde5a6d#diff-04b8604ebdfab5084aa24cb21f0d1dea,
globus auth is broken otherwise