### PR TITLE
use two replicas of the user scheduler, to allow for one to be evicted

### DIFF
--- a/pangeo/values.yaml
+++ b/pangeo/values.yaml
@@ -31,6 +31,7 @@ jupyterhub:
   scheduling:
     userScheduler:
       enabled: true
+      replicas: 2
     podPriority:
       enabled: true
     userPlaceholder:


### PR DESCRIPTION
per @consideRatio's [comment](https://github.com/pangeo-data/helm-chart/pull/87#issuecomment-471114615).