### PR TITLE
Update jupyterhub helm chart to 0.8.2

### DIFF
--- a/pangeo/requirements.yaml
+++ b/pangeo/requirements.yaml
@@ -1,7 +1,7 @@
 # requirements.yaml
 dependencies:
 - name: jupyterhub
-  version: "0.9-e120fda"
+  version: "0.8.2"
   repository: 'https://jupyterhub.github.io/helm-chart/'
   import-values:
     - child: rbac


### PR DESCRIPTION
Addresses [open redirect vulnerability](https://blog.jupyter.org/open-redirect-vulnerability-in-jupyter-jupyterhub-adf43583f1e4)

Fixes #90 