### PR TITLE
back to development jhub chart version

### DIFF
--- a/pangeo/requirements.yaml
+++ b/pangeo/requirements.yaml
@@ -1,7 +1,7 @@
 # requirements.yaml
 dependencies:
 - name: jupyterhub
-  version: "0.8.2"
+  version: "0.9-8ed2f81"
   repository: 'https://jupyterhub.github.io/helm-chart/'
   import-values:
     - child: rbac


### PR DESCRIPTION
This [development version](https://blog.jupyter.org/open-redirect-vulnerability-in-jupyter-jupyterhub-adf43583f1e4) of the jhub chart was released on March 28, the same day as the [open redirect announcement](https://blog.jupyter.org/open-redirect-vulnerability-in-jupyter-jupyterhub-adf43583f1e4). I assume it also has the necessary security fixes for #90, plus the added advantage of not breaking our existing clusters.