### PR TITLE
Allow users to get/list/watch/create/delete services

### DIFF
--- a/pangeo/templates/dask-kubernetes-rbac.yaml
+++ b/pangeo/templates/dask-kubernetes-rbac.yaml
@@ -24,7 +24,7 @@ metadata:
     release: {{ .Release.Name }}
 rules:
 - apiGroups: [""] # "" indicates the core API group
-  resources: ["pods"]
+  resources: ["pods", "services"]
   verbs: ["get", "list", "watch", "create", "delete"]
 - apiGroups: [""] # "" indicates the core API group
   resources: ["pods/log"]


### PR DESCRIPTION
As of dask/dask-kubernetes#162 the `KubeCluster` manager will need to be able to create kubernetes services. This is because the scheduler will no longer be be local to the `KubeCluster` object but instead a pod within the cluster. In order to route traffic from the local session to the scheduler a service needs to be created.