### PR TITLE
Version bumps for dependencies

### DIFF
--- a/pangeo/requirements.yaml
+++ b/pangeo/requirements.yaml
@@ -1,7 +1,7 @@
 # requirements.yaml
 dependencies:
 - name: jupyterhub
-  version: "0.9-dcde99a"
+  version: "0.9-7738a96"
   repository: 'https://jupyterhub.github.io/helm-chart/'
   import-values:
     - child: rbac

--- a/pangeo/values.yaml
+++ b/pangeo/values.yaml
@@ -20,9 +20,9 @@ jupyterhub:
   singleuser:
     image:
       name: pangeo/base-notebook
-      tag: 2019.07.01
+      tag: 2019.09.23
     defaultUrl: "/lab"
-    cmd: jupyter-labhub
+    cmd: jupyter
     serviceAccountName: daskkubernetes
   prePuller:
     hook:

--- a/pangeo/values.yaml
+++ b/pangeo/values.yaml
@@ -22,7 +22,6 @@ jupyterhub:
       name: pangeo/base-notebook
       tag: 2019.09.23
     defaultUrl: "/lab"
-    cmd: jupyter
     serviceAccountName: daskkubernetes
   prePuller:
     hook:


### PR DESCRIPTION
Jupyterhub --> 0.9-7738a9
pangeo/base-notebook --> 2019.09.23

Also, remove singleuser.cmd since jupyterlab-hub is deprecated now.