### PR TITLE
Bump to chartpress 0.6.*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 
 install:
 - curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
-- pip install chartpress==0.3.2
+- pip install chartpress==0.6
 script:
 - chartpress --image-prefix=. --tag `date +%y.%m.%d`
 - git diff

--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -4,4 +4,3 @@ charts:
       git: pangeo-data/helm-chart
       published: https://pangeo-data.github.io/helm-chart
     images: {}
-    imagePrefix: 

--- a/deploy.sh
+++ b/deploy.sh
@@ -9,5 +9,5 @@ helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
 helm repo update
 helm dependency update pangeo
 export GIT_SSH_COMMAND="ssh -i ${PWD}/deploy-key.rsa"
-chartpress --commit-range ${TRAVIS_COMMIT_RANGE} --publish-chart $@
+chartpress --publish-chart $@
 git diff


### PR DESCRIPTION
Just to keep up to date and remove some deprecated logic and workarounds of old chartpress issues.

As you specify `--tag` when you use chartpress in this repo, you will not be exposed to the breaking changes between `0.3.2` and `0.6.0`.

I've added a lot of tests to chartpress itself, and made it a lot easier to update in the future with some CI/CD. I wanted to create this PR and get you updated in order to not be worried later about the changes when a future version bump could be needed for a future feature.

- Note that `--commit-range` is removed because it is now no longer needed and does nothing.
- Note that blank `imagePrefix: ` configuration of chartpress in [chartpress.yaml] was removed as it was only a workaround for a bug that is now fixed.