### PR TITLE
Bump chartpress to 0.6.* and maintenance of chart publishing logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
 - curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
 - pip install chartpress==0.3.2
 script:
-- chartpress --image-prefix=. --tag `date +%y.%m.%d`
+- chartpress --tag `date +%y.%m.%d`
 - git diff
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,17 @@
-sudo: required
-
+dist: bionic
 language: python
-python:
-- '3.6'
+python: 3.6
 
 install:
 - curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
-- pip install chartpress==0.3.2
+- pip install chartpress==0.6
+
 script:
 - chartpress
 - git diff
 
 deploy:
   - provider: script
-    skip_cleanup: true
     script: bash deploy.sh
     on:
       # Only deploy when pushing to master branch or a git tag

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,14 @@ install:
 - curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
 - pip install chartpress==0.3.2
 script:
-- chartpress --tag `date +%y.%m.%d`
+- chartpress
 - git diff
 
 deploy:
   - provider: script
     skip_cleanup: true
-    script: bash deploy.sh 
+    script: bash deploy.sh
     on:
-      branch: master
-      tags: false
-  - provider: script
-    skip_cleanup: true
-    script: bash deploy.sh --tag `date +%y.%m.%d`
-    on:
+      # Only deploy when pushing to master branch or a git tag
       branch: master
       tags: true

--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -1,7 +1,7 @@
+# The chartpress CLI configuration reference is available at
+# https://github.com/jupyterhub/chartpress#configuration.
 charts:
   - name: pangeo
     repo:
       git: pangeo-data/helm-chart
       published: https://pangeo-data.github.io/helm-chart
-    images: {}
-    imagePrefix: 

--- a/deploy.sh
+++ b/deploy.sh
@@ -9,5 +9,5 @@ helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
 helm repo update
 helm dependency update pangeo
 export GIT_SSH_COMMAND="ssh -i ${PWD}/deploy-key.rsa"
-chartpress --commit-range ${TRAVIS_COMMIT_RANGE} --publish-chart $@
+chartpress --publish-chart $@
 git diff

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,13 +1,27 @@
 #!/bin/bash
 
+# Deploying means to package and make available a Helm chart in the Helm chart
+# repostiory hosted as a GitHub pages website. GitHub pages websites are hosted
+# by GitHub automatically if we push to a github repository of a certain branch
+# called gh-pages.
+#
+# See:
+# - gh-pages branch: https://github.com/pangeo-data/helm-chart/tree/gh-pages
+# - Rendered GitHub pages: https://pangeo-data.github.io/helm-chart/
+
+# We need to provide credentails to push to the the git repository configured in
+# chartpress.yaml, which is this git repo. The push will be made by chartpress
+# and be made to the gh-pages branch specifically.
 set -eu
 openssl aes-256-cbc -K $encrypted_058f1ad78f7f_key -iv $encrypted_058f1ad78f7f_iv -in deploy-key.rsa.enc -out deploy-key.rsa -d
 set -x
 chmod 0400 deploy-key.rsa
-helm init --client-only
-helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
-helm repo update
-helm dependency update pangeo
 export GIT_SSH_COMMAND="ssh -i ${PWD}/deploy-key.rsa"
+
+# Initialize helm CLI for use by chartpress to package a helm chart and publish
+# it using configuration in chartpress.yaml.
+helm init --client-only
 chartpress --publish-chart $@
+
+# Provide a trace of what chartpress did for the logs
 git diff

--- a/pangeo/Chart.yaml
+++ b/pangeo/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: pangeo
-version: AUTO_POPULATED_BY_CHARTPRESS_AND_TRAVIS
+version: 0.0.1-set.by.chartpress
 description: An extention of jupyterhub with extra Pangeo resources
 maintainers:
   - name: Jacob Tomlinson (Met Office)


### PR DESCRIPTION
## Summary
This PR is mainly a PR to ensure we don't get stuck in an old version of chartpress and help to make future work using chartpress easier.

## About
This repo's currently used chartpress (0.3.2) will version and name development releases differently to the most recent chartpress (0.6.0). The most recent chartpress determines the chart version using the latest git tag of a commit on the current branch, the number of commits since it, and the git hash, as described [here](https://github.com/jupyterhub/chartpress#how-chart-version-and-image-tags-are-determined).

With this PR we transition away from having dates in the chart version. We go from `20.01.03-d9f0cde`, to `<latest tag>-n<# commits since latest tag>.h<git hash of commit>` or `<latest tag>` if the current commit was tagged and `--long` wasn't provided. If we want to have the date in the version still, we need to manually provide `--tag` with both date and hash whenever we use chartpress.

## Important
Whatever we do, I think we should ensure Helm 3 compatibility by having valid SemVer 2 versions. Valid SemVer 2 versions require all numerical fields to not start with a leading zero, and that only one separating `-` is used among other things. This means that `20.01.13-asdf123` for example is invalid because the 01 representing january is purely numerical with a leading zero.

Since the latest tag is used, we should make chartpress strip leading `v` characters such as in `v0.2.2` as that would make an invalid SemVer 2 version. This is currently not done in chartpress so I suggest start tagging valid SemVer 2 versions going onwards while I work to make chartpress support use of `v` prefix in a tag.