### PR TITLE
Revert "Bump to chartpress 0.6.*"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 
 install:
 - curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
-- pip install chartpress==0.6
+- pip install chartpress==0.3.2
 script:
 - chartpress --image-prefix=. --tag `date +%y.%m.%d`
 - git diff

--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -4,3 +4,4 @@ charts:
       git: pangeo-data/helm-chart
       published: https://pangeo-data.github.io/helm-chart
     images: {}
+    imagePrefix: 

--- a/deploy.sh
+++ b/deploy.sh
@@ -9,5 +9,5 @@ helm repo add jupyterhub https://jupyterhub.github.io/helm-chart/
 helm repo update
 helm dependency update pangeo
 export GIT_SSH_COMMAND="ssh -i ${PWD}/deploy-key.rsa"
-chartpress --publish-chart $@
+chartpress --commit-range ${TRAVIS_COMMIT_RANGE} --publish-chart $@
 git diff


### PR DESCRIPTION
Let's revert the change first, so we can better discuss the actual change that will follow bumping chartpress and resolving some changes now that I better have analyzed the situation.

This PR reverts the change that caused development release build failures: pangeo-data/helm-chart#113