### PR TITLE
Run deploy script for master/tag pushes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,7 @@ deploy:
     script: bash deploy.sh
     on:
       # Only deploy when pushing to master branch or a git tag
-      branch: master
-      tags: true
+      condition: '"$TRAVIS_TAG" != "" || "$TRAVIS_BRANCH" == "master"'
+      # Without all_branches: true, the condition will only be evaluated for the
+      # master branch and tags.
+      all_branches: true


### PR DESCRIPTION
Followup #114. Yikes TravisCI isn't easy to get right, it is the shell scripting of CI/CD.

After introducing #114, I mistakenly restricted deployment script execution to when we push tags. This should make us run the deployment script for pushes to master as well as pushed tags.