### PR TITLE
Bump Z2JH to 0.9.0 from 0.9.0-beta.4.n008.hb20ad22

### DIFF
--- a/pangeo/Chart.yaml
+++ b/pangeo/Chart.yaml
@@ -4,7 +4,7 @@ version: 0.0.1-set.by.chartpress
 description: An extention of jupyterhub with extra Pangeo resources
 dependencies:
   - name: jupyterhub
-    version: "0.9.0-beta.4.n008.hb20ad22"
+    version: "0.9.0"
     repository: 'https://jupyterhub.github.io/helm-chart/'
     import-values:
       - child: rbac


### PR DESCRIPTION
This may be required for use of the user-scheduler with k8s 1.16.