### PR TITLE
dask-gateway: conditional install with dask-gateway.enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,4 @@ scheduler.json
 # Helm stuff
 */charts
 requirements.lock
+Chart.lock

--- a/pangeo/Chart.yaml
+++ b/pangeo/Chart.yaml
@@ -13,6 +13,7 @@ dependencies:
     # Make sure to update the dask-gateway CRDs in .circleci/config.yml
     version: "0.7.1"
     repository: 'https://dask.org/dask-gateway-helm-repo/'
+    condition: dask-gateway.enabled
 maintainers:
   - name: Jacob Tomlinson (Met Office)
     email: jacob.tomlinson@informaticslab.co.uk

--- a/pangeo/templates/dask-kubernetes-rbac.yaml
+++ b/pangeo/templates/dask-kubernetes-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.dask-kubernetes.enabled .Values.rbac.enabled -}}
+{{- if and (index .Values "dask-kubernetes" "enabled") .Values.rbac.enabled -}}
 kind: ServiceAccount
 apiVersion: v1
 metadata:

--- a/pangeo/templates/dask-kubernetes-rbac.yaml
+++ b/pangeo/templates/dask-kubernetes-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.enabled -}}
+{{- if and .Values.dask-kubernetes.enabled .Values.rbac.enabled -}}
 kind: ServiceAccount
 apiVersion: v1
 metadata:
@@ -49,4 +49,4 @@ roleRef:
   kind: Role
   name: daskkubernetes
   apiGroup: rbac.authorization.k8s.io
-{{- end -}}
+{{- end }}

--- a/pangeo/values.yaml
+++ b/pangeo/values.yaml
@@ -58,7 +58,7 @@ dask-kubernetes:
   # Role which is part of this Helm chart. To fully disable the use of these,
   # you should not only set this enabled flag to false but also set
   # jupyterhub.singleuser.serviceAccountName to null.
-  enabled: true
+  enabled: false
 
 dask-gateway:
   # Enabling this means to install the dask-gateway Helm chart as a dependency.

--- a/pangeo/values.yaml
+++ b/pangeo/values.yaml
@@ -54,6 +54,8 @@ jupyterhub:
 #      guarantee: 2G
 
 dask-gateway:
+  enabled: true
+
   # dask-gateway configuration goes here
   # See https://github.com/dask/dask-gateway/blob/master/resources/helm/dask-gateway/values.yaml
   # The values here are optimized for deployment within a jupyterhub.

--- a/pangeo/values.yaml
+++ b/pangeo/values.yaml
@@ -53,7 +53,15 @@ jupyterhub:
 #      limit: 4G
 #      guarantee: 2G
 
+dask-kubernetes:
+  # Enabling this means to install a Kubernetes ServiceAccount, RoleBinding, and
+  # Role which is part of this Helm chart. To fully disable the use of these,
+  # you should not only set this enabled flag to false but also set
+  # jupyterhub.singleuser.serviceAccountName to null.
+  enabled: true
+
 dask-gateway:
+  # Enabling this means to install the dask-gateway Helm chart as a dependency.
   enabled: true
 
   # dask-gateway configuration goes here


### PR DESCRIPTION
Perhaps one doesn't want to install dask-gateway, then the dask-gateway.enabled Helm chart configuration can be used to disable it.

Technical reference on the Helm mechanism used, see: https://helm.sh/docs/chart_best_practices/dependencies/#conditions-and-tags